### PR TITLE
Support excluding entries in the sitemap

### DIFF
--- a/config/sitemap.php
+++ b/config/sitemap.php
@@ -3,4 +3,17 @@
 return [
     'url' => 'sitemap.xml',
     'expire' => 60,
+    'include_entries' => true,
+    'include_terms' => true,
+    'include_collection_terms' => true,
+    /**
+     * - Leave as `null` for all types
+     * - Provide array of types/handles for filtering
+     */
+    'entry_types' => null,
+    /**
+     * - Use valid regex patterns (uses `preg_match`)
+     * - Relative URLs (relative to site url)
+     */
+    'exclude_urls' => []
 ];

--- a/src/Models/Sitemap.php
+++ b/src/Models/Sitemap.php
@@ -43,9 +43,9 @@ class Sitemap
         });
     }
 
-    protected static function publishedEntries(): \Illuminate\Support\Collection
+    protected function publishedEntries(): \Illuminate\Support\Collection
     {
-        $exluded_urls = self::getExcludedUrlCollection();
+        $exluded_urls = $this->getExcludedUrlCollection();
         $entry_types = config('pecotamic.sitemap.entry_types');
 
         return Collection::all()
@@ -58,7 +58,7 @@ class Sitemap
                 }
 
                 // is excluded by url pattern?
-                if (self::isExcluded($entry->url(), $exluded_urls)) {
+                if ($this->isExcluded($entry->url(), $exluded_urls)) {
                     return false;
                 }
 
@@ -71,9 +71,9 @@ class Sitemap
             });
     }
 
-    protected static function publishedTerms()
+    protected function publishedTerms()
     {
-        $exluded_urls = self::getExcludedUrlCollection();
+        $exluded_urls = $this->getExcludedUrlCollection();
 
         return Taxonomy::all()
             ->flatMap(function ($taxonomy) {
@@ -82,7 +82,7 @@ class Sitemap
             ->filter
             ->published()
             ->filter(function ($term) use ($exluded_urls) {
-                if (self::isExcluded($term->url(), $exluded_urls)) {
+                if ($this->isExcluded($term->url(), $exluded_urls)) {
                     return false;
                 }
 
@@ -90,9 +90,9 @@ class Sitemap
             });
     }
 
-    protected static function publishedCollectionTerms()
+    protected function publishedCollectionTerms()
     {
-        $exluded_urls = self::getExcludedUrlCollection();
+        $exluded_urls = $this->getExcludedUrlCollection();
 
         return Collection::all()
             ->flatMap(function ($collection) {
@@ -104,7 +104,7 @@ class Sitemap
             ->filter
             ->published()
             ->filter(function ($term) use ($exluded_urls) {
-                if (self::isExcluded($term->url(), $exluded_urls)) {
+                if ($this->isExcluded($term->url(), $exluded_urls)) {
                     return false;
                 }
 
@@ -112,14 +112,14 @@ class Sitemap
             });
     }
 
-    private static function isExcluded($url, $exluded_urls)
+    private function isExcluded($url, $exluded_urls)
     {
         return $exluded_urls->contains(function ($value) use ($url) {
             return preg_match($value, $url);
         });
     }
 
-    private static function getExcludedUrlCollection()
+    private function getExcludedUrlCollection()
     {
         return collect(config('pecotamic.sitemap.exclude_urls', []));
     }

--- a/src/Models/Sitemap.php
+++ b/src/Models/Sitemap.php
@@ -16,15 +16,15 @@ class Sitemap
 
         $entries = collect();
 
-        if (config('pecotamic.sitemap.include_entries')) {
+        if (config('pecotamic.sitemap.include_entries', true)) {
             $entries = $entries->merge(self::toSitemapEntries($sitemap->publishedEntries()));
         }
 
-        if (config('pecotamic.sitemap.include_terms')) {
+        if (config('pecotamic.sitemap.include_terms', true)) {
             $entries = $entries->merge(self::toSitemapEntries($sitemap->publishedTerms()));
         }
 
-        if (config('pecotamic.sitemap.include_collection_terms')) {
+        if (config('pecotamic.sitemap.include_collection_terms', true)) {
             $entries = $entries->merge(self::toSitemapEntries($sitemap->publishedCollectionTerms()));
         }
 
@@ -43,7 +43,7 @@ class Sitemap
         });
     }
 
-    protected function publishedEntries(): \Illuminate\Support\Collection
+    protected static function publishedEntries(): \Illuminate\Support\Collection
     {
         $exluded_urls = self::getExcludedUrlCollection();
         $entry_types = config('pecotamic.sitemap.entry_types');
@@ -57,12 +57,12 @@ class Sitemap
                     return false;
                 }
 
-                // is excluded by url pattern
+                // is excluded by url pattern?
                 if (self::isExcluded($entry->url(), $exluded_urls)) {
                     return false;
                 }
 
-                // is an included entry type
+                // is an included entry type?
                 if ($entry_types !== null && !in_array($entry->collectionHandle(), $entry_types)) {
                     return false;
                 }
@@ -71,7 +71,7 @@ class Sitemap
             });
     }
 
-    protected function publishedTerms()
+    protected static function publishedTerms()
     {
         $exluded_urls = self::getExcludedUrlCollection();
 
@@ -82,8 +82,7 @@ class Sitemap
             ->filter
             ->published()
             ->filter(function ($term) use ($exluded_urls) {
-
-                if (self::isExcluded($entry->url(), $exluded_urls)) {
+                if (self::isExcluded($term->url(), $exluded_urls)) {
                     return false;
                 }
 
@@ -91,7 +90,7 @@ class Sitemap
             });
     }
 
-    protected function publishedCollectionTerms()
+    protected static function publishedCollectionTerms()
     {
         $exluded_urls = self::getExcludedUrlCollection();
 
@@ -105,8 +104,7 @@ class Sitemap
             ->filter
             ->published()
             ->filter(function ($term) use ($exluded_urls) {
-
-                if (self::isExcluded($entry->url(), $exluded_urls)) {
+                if (self::isExcluded($term->url(), $exluded_urls)) {
                     return false;
                 }
 
@@ -121,7 +119,7 @@ class Sitemap
         });
     }
 
-    private function getExcludedUrlCollection()
+    private static function getExcludedUrlCollection()
     {
         return collect(config('pecotamic.sitemap.exclude_urls', []));
     }

--- a/src/Models/Sitemap.php
+++ b/src/Models/Sitemap.php
@@ -14,10 +14,21 @@ class Sitemap
     {
         $sitemap = new static;
 
-        return collect()
-            ->merge(self::toSitemapEntries($sitemap->publishedEntries()))
-            ->merge(self::toSitemapEntries($sitemap->publishedTerms()))
-            ->merge(self::toSitemapEntries($sitemap->publishedCollectionTerms()))
+        $entries = collect();
+
+        if (config('pecotamic.sitemap.include_entries')) {
+            $entries = $entries->merge(self::toSitemapEntries($sitemap->publishedEntries()));
+        }
+
+        if (config('pecotamic.sitemap.include_terms')) {
+            $entries = $entries->merge(self::toSitemapEntries($sitemap->publishedTerms()));
+        }
+
+        if (config('pecotamic.sitemap.include_collection_terms')) {
+            $entries = $entries->merge(self::toSitemapEntries($sitemap->publishedCollectionTerms()));
+        }
+
+        return $entries
             ->values()
             ->sortBy(function (SitemapEntry $entry) {
                 return substr_count(rtrim($entry->path, '/'), '/');
@@ -34,12 +45,25 @@ class Sitemap
 
     protected function publishedEntries(): \Illuminate\Support\Collection
     {
+        $exluded_urls = self::getExcludedUrlCollection();
+        $entry_types = config('pecotamic.sitemap.entry_types');
+
         return Collection::all()
             ->flatMap(function ($collection) {
                 return $collection->queryEntries()->get();
             })
-            ->filter(function ($entry) {
+            ->filter(function ($entry) use ($exluded_urls, $entry_types) {
                 if (!preg_match('#^https?://#', $entry->absoluteUrl())) {
+                    return false;
+                }
+
+                // is excluded by url pattern
+                if (self::isExcluded($entry->url(), $exluded_urls)) {
+                    return false;
+                }
+
+                // is an included entry type
+                if ($entry_types !== null && !in_array($entry->collectionHandle(), $entry_types)) {
                     return false;
                 }
 
@@ -49,19 +73,28 @@ class Sitemap
 
     protected function publishedTerms()
     {
+        $exluded_urls = self::getExcludedUrlCollection();
+
         return Taxonomy::all()
             ->flatMap(function ($taxonomy) {
                 return $taxonomy->queryTerms()->get();
             })
             ->filter
             ->published()
-            ->filter(function ($term) {
+            ->filter(function ($term) use ($exluded_urls) {
+
+                if (self::isExcluded($entry->url(), $exluded_urls)) {
+                    return false;
+                }
+
                 return view()->exists($term->template());
             });
     }
 
     protected function publishedCollectionTerms()
     {
+        $exluded_urls = self::getExcludedUrlCollection();
+
         return Collection::all()
             ->flatMap(function ($collection) {
                 return $collection->taxonomies()->map->collection($collection);
@@ -71,8 +104,25 @@ class Sitemap
             })
             ->filter
             ->published()
-            ->filter(function ($term) {
+            ->filter(function ($term) use ($exluded_urls) {
+
+                if (self::isExcluded($entry->url(), $exluded_urls)) {
+                    return false;
+                }
+
                 return view()->exists($term->template());
             });
+    }
+
+    private static function isExcluded($url, $exluded_urls)
+    {
+        return $exluded_urls->contains(function ($value) {
+            return preg_match($value, $url);
+        });
+    }
+
+    private function getExcludedUrlCollection()
+    {
+        return collect(config('pecotamic.sitemap.exclude_urls', []));
     }
 }

--- a/src/Models/Sitemap.php
+++ b/src/Models/Sitemap.php
@@ -116,7 +116,7 @@ class Sitemap
 
     private static function isExcluded($url, $exluded_urls)
     {
-        return $exluded_urls->contains(function ($value) {
+        return $exluded_urls->contains(function ($value) use ($url) {
             return preg_match($value, $url);
         });
     }


### PR DESCRIPTION
This adds more optional configuration:
* Entries can be excluded altogether, or only certain types of entries can be included
* Regex patterns can be used to exclude items (using relative paths)