### PR TITLE
Use correct content type for sitemap.xml

### DIFF
--- a/src/Http/Controllers/SitemapController.php
+++ b/src/Http/Controllers/SitemapController.php
@@ -20,6 +20,6 @@ class SitemapController extends Controller
             ])->render();
         });
 
-        return response($content)->header('Content-Type', 'text/xml')->header('Expires', $cacheUntil->format('D, d M Y H:i:s T'));
+        return response($content)->header('Content-Type', 'application/xml')->header('Expires', $cacheUntil->format('D, d M Y H:i:s T'));
     }
 }


### PR DESCRIPTION
I got some validation errors cause the content type was set to `text/xml`. Therefore I changed it to `application/xml` which will lead in correct validations.