### PR TITLE
Feature: ability to add extra entries programmatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor
+.idea


### PR DESCRIPTION
This PR adds the ability to register new SitemapEntries programmatically.

This is useful when you have custom routes / controllers defined i.e. `Route::statamic('blog/authors/{slug}', 'authors.show');`

The usage is similar to adding routes dynamically in Statamic's SSG add-on (https://github.com/statamic/ssg)

Here is an example of how to use it:

In `AppServiceProvider.php`
<img width="774" alt="image" src="https://user-images.githubusercontent.com/846343/168745173-b8be8b39-9b5f-46c1-acb9-2423cb2751f3.png">


