### PR TITLE
Check for Entry status instead of published bool

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -104,7 +104,7 @@ class Generator extends Facade
                     return false;
                 }
 
-                return $entry->published();
+                return $entry->status() === 'published';
             });
     }
 


### PR DESCRIPTION
Fixes https://github.com/pecotamic/sitemap/issues/22.

This small tweak leaves Entries out that are not supposed to be publicly accessible.

Please test it properly. It was just me doing a quick change.