### PR TITLE
Allow invokable class as filter

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -45,6 +45,7 @@ class Generator extends Facade
 
         // filter by function
         if ($callback = config('pecotamic.sitemap.filter')) {
+            $callback = is_string($callback) ? new $callback() : $callback;
             $entries = $entries->filter($callback);
         }
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -45,8 +45,10 @@ class Generator extends Facade
 
         // filter by function
         if ($callback = config('pecotamic.sitemap.filter')) {
-            $callback = is_string($callback) ? new $callback() : $callback;
-            $entries = $entries->filter($callback);
+            $callback = is_string($callback) && class_exists($callback) ? new $callback() : $callback;
+            if (is_callable($callback)) {
+                $entries = $entries->filter($callback);
+            }
         }
 
         // find entries

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -46,9 +46,7 @@ class Generator extends Facade
         // filter by function
         if ($callback = config('pecotamic.sitemap.filter')) {
             $callback = is_string($callback) && class_exists($callback) ? new $callback() : $callback;
-            if (is_callable($callback)) {
-                $entries = $entries->filter($callback);
-            }
+            $entries = $entries->filter($callback);
         }
 
         // find entries


### PR DESCRIPTION
To simplify config handling, this PR allows an invokable class to be used for filtering in addition to an anonymous function.

This also improve serialization for config caching.